### PR TITLE
refactor Games controller so that no non-RESTful routes are needed

### DIFF
--- a/app/javascript/components/Game.jsx
+++ b/app/javascript/components/Game.jsx
@@ -22,7 +22,7 @@ export const Game = () => {
     const [newSession, setNewSession] = useState(false)
 
     useEffect(() => {
-        getData(`user_game/${id}`, setData, setError)
+        getData(`games/${id}`, setData, setError)
     }, [edit, create, newSession])
 
     useEffect(() => {

--- a/app/javascript/components/Games.jsx
+++ b/app/javascript/components/Games.jsx
@@ -23,7 +23,7 @@ export const Games = ({endpoint, loading, user, homeError = null}) => {
     const [numCategories, setNumCategories] = useState(0)
 
     useEffect(() => {
-        getData(`${user ? 'user_games' : 'games'}${search ? `?name=${search}`: ''}`, setData, homeError || setError)
+        getData(`games${search ? `?name=${search}`: ''}`, setData, homeError || setError)
     }, [create, search, user, loading])
 
     const list = data?.map((p) => (

--- a/app/javascript/components/__tests__/Games.test.js
+++ b/app/javascript/components/__tests__/Games.test.js
@@ -22,7 +22,7 @@ jest.mock('../helpers/useSetUser', () => ({
 
 describe('Games component works correctly', () => {
     test('you can enter a search', async () => {
-        render(<Games endpoint='user_games' user={true} />)
+        render(<Games endpoint='games' user={true} />)
         const search = screen.queryByRole('textbox')
         expect(search.value).toBe('')
         await user.type(search, 'Wingspan')
@@ -39,7 +39,7 @@ describe('Games component works correctly', () => {
     });
 
     test('clicking "Add New Game" shows the form', async() => {
-        render(<Games endpoint='user_games' user={true} />)
+        render(<Games endpoint='games' user={true} />)
         await user.click(screen.getByText('Add New Game'))
         expect(screen.getByText('See All Games')).toBeDefined()
     });
@@ -57,7 +57,7 @@ describe('Games component works correctly', () => {
     });
 
     test('Has searchbar if My Games', () => {
-        render(<Games endpoint='user_games' user={true} />)
+        render(<Games endpoint='games' user={true} />)
         expect(screen.queryByRole('textbox')).not.toBe(null)
         expect(screen.getByText('Add New Game')).not.toBe(null)
     });

--- a/app/javascript/routes/RoutesIndex.jsx
+++ b/app/javascript/routes/RoutesIndex.jsx
@@ -21,7 +21,7 @@ export const RoutesIndex = ({user, setUser, error, setError, setLoading, loading
         <Route path='/' element={<Home user={user} loading={loading} setLoading={setLoading} setUser={setUser} error={error} setError={setError}/>} />
         <Route path="/user" element={<User user={user} setError={setError}/>} />
         <Route path="/players" element={<Players user={user} setError={setError} error={error}/>} />
-        <Route path="/games" element={<Games user={user} endpoint='user_games' setError={setError}/>} />
+        <Route path="/games" element={<Games user={user} endpoint='games' setError={setError}/>} />
         <Route path="/games/:id" element={<Game />} />
         <Route path="/sessions/:id" element={<Session setError={setError}/>} />
         <Route path="/login" element={<Login user={user} setUser={setUser} setError={setError}/>} />

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,8 +6,7 @@ Rails.application.routes.draw do
     resources :sessions
     resources :categories
     resources :games
-    get 'user_games', to: 'games#user_games'
-    get 'user_game/:id', to: 'games#user_game'
+    #get 'user_game/:id', to: 'games#user_game'
     get 'session_winner/:id', to: 'sessions#get_winner'
     resources :players
     devise_for :users,


### PR DESCRIPTION
### Made the Games controller more RESTful

The Games controller had a few methods that were non-RESTful, and I realized I could just not use those methods and keep everything in the normal RESTful routes/methods with the help of a private method instead. I refactored this controller so that it only has RESTful routes, and made sure the frontend was no longer calling the non-RESTful routes anywhere