### PR TITLE
Standardize api responses

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -9,10 +9,7 @@ class SessionsController < ApplicationController
   # GET /sessions/1 or /sessions/1.json
   def show
     @players = current_user.players
-    @session = JSON.parse(@session.to_json(:include => [:game, :user, :collaborators, {:session_players => {:include => [:session_scores]}}, 
-            {:session_categories => {:include => [:session_scores]}}, 
-            {:session_scores=> {:include => [:session_player, :session_category]}}]))
-    render json: {session: @session, players: @players }
+    render json: {session: JSON.parse(@session.session_relationships), players: @players }
   end
 
   def winner

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -8,8 +8,11 @@ class SessionsController < ApplicationController
 
   # GET /sessions/1 or /sessions/1.json
   def show
-    @players = current_user.players
-    render json: {session: JSON.parse(@session.session_relationships), players: @players }
+    include_options = build_include_options
+
+    render json: @session.as_json(include: include_options)
+    #@players = current_user.players
+    #render json: {session: JSON.parse(@session.session_relationships), players: @players }
   end
 
   def winner
@@ -53,6 +56,29 @@ class SessionsController < ApplicationController
   end
 
   private
+
+    def build_include_options
+      return {} unless params[:include]
+
+      params[:include].split(',').map do |association|
+        case association
+        when 'players'
+          { user: {include: :players }}
+        when 'game'
+          { game: @session.game }
+        when 'collaborators'
+          { collaborators: {}}
+        when 'session_scores'
+          { session_scores: {include: [:session_player, :session_category]}}
+        when 'session_players'
+          { session_players: {include: :session_scores }}
+        when 'session_categories'
+          { session_categories: {include: :session_scores }}
+        else
+          {}
+        end
+      end.reduce({}, :merge)
+    end
     # Use callbacks to share common setup or constraints between actions.
     def set_session
       @session = Session.find(params[:id])

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -11,8 +11,6 @@ class SessionsController < ApplicationController
     include_options = build_include_options
 
     render json: @session.as_json(include: include_options)
-    #@players = current_user.players
-    #render json: {session: JSON.parse(@session.session_relationships), players: @players }
   end
 
   def winner

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,10 +3,30 @@ class UsersController < ApplicationController
   skip_before_action :authenticate_user!
     
     def show
-      render json: current_user.as_json(:include => 
-        [ {:games => {:include => [:sessions]}}, 
-          {:sessions => {:include => [:user]}}, 
-          {:shared_sessions => {:include => [:user]}} ] ) || false
+
+      include_options = build_include_options
+
+      render json: current_user.as_json(include: include_options) || false
     end
+
+    private
+
+    def build_include_options
+      return {} unless params[:include]
+
+      params[:include].split(',').map do |association|
+        case association
+        when 'games'
+          { games: {include: :sessions}}
+        when 'sessions'
+          { sessions: {include: :user}}
+        when 'shared_sessions'
+          { shared_sessions: {include: :user}}
+        else
+          {}
+        end
+      end.reduce({}, :merge)
+    end
+
 
 end

--- a/app/javascript/components/Form.jsx
+++ b/app/javascript/components/Form.jsx
@@ -12,6 +12,7 @@ export const Form = ({submitter = null, navigate = null, className = null, style
         let info = {}
         info = form_object(item, info, data)
         const response = info[item]?.name !== '' ? await updater(`${endpoint}${id ? `/${id}` : ''}`, info, setError) : null
+
         if (response?.error){
             return
         } else {

--- a/app/javascript/components/Game.jsx
+++ b/app/javascript/components/Game.jsx
@@ -22,7 +22,9 @@ export const Game = () => {
     const [newSession, setNewSession] = useState(false)
 
     useEffect(() => {
-        getData(`games/${id}`, setData, setError)
+        getData(`games/${id}`, setData, setError,
+            ['categories', 'sessions', 'session_shares', 'results']
+        )
     }, [edit, create, newSession])
 
     useEffect(() => {

--- a/app/javascript/components/Games.jsx
+++ b/app/javascript/components/Games.jsx
@@ -23,7 +23,7 @@ export const Games = ({endpoint, loading, user, homeError = null}) => {
     const [numCategories, setNumCategories] = useState(0)
 
     useEffect(() => {
-        getData(`games${search ? `?name=${search}`: ''}`, setData, homeError || setError)
+        getData(`games${search ? `?name=${search}`: ''}`, setData, homeError || setError, ['sessions'])
     }, [create, search, user, loading])
 
     const list = data?.map((p) => (

--- a/app/javascript/components/Home.jsx
+++ b/app/javascript/components/Home.jsx
@@ -7,7 +7,7 @@ export const Home = ({user, setUser, loading, setLoading, setError, error}) => {
 
     useEffect(() => {
         setLoading(true)
-        getData('user', setUser, setError)
+        getData('user', setUser, setError, ['sessions', 'shared_sessions'])
         setLoading(false)
     }, [loading])
 

--- a/app/javascript/components/ScoresTable.jsx
+++ b/app/javascript/components/ScoresTable.jsx
@@ -3,9 +3,9 @@ import { Form } from "./Form";
 import { Input } from "./Input";
 import { Submit } from "./Submit";
 
-export const ScoresTable = ({data, players, totals, styling, enterScores, updateData, setData, setError, WIN_TYPE}) => {
+export const ScoresTable = ({ data, players, totals, styling, enterScores, updateData, setData, setError, WIN_TYPE }) => {
 
-    const scores = data?.session?.session_categories?.map((c) => ( 
+    const scores = data?.session_categories?.map((c) => ( 
         <div key={c.id} className="row" style={styling}>
             <div>{c?.name}</div>
             {c?.session_scores?.map((score) => !enterScores ? 

--- a/app/javascript/components/Session.jsx
+++ b/app/javascript/components/Session.jsx
@@ -35,7 +35,8 @@ export const Session = () => {
     const share_img = <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16"> <path d="M13.5 1a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3zM11 2.5a2.5 2.5 0 1 1 .603 1.628l-6.718 3.12a2.499 2.499 0 0 1 0 1.504l6.718 3.12a2.5 2.5 0 1 1-.488.876l-6.718-3.12a2.5 2.5 0 1 1 0-3.256l6.718-3.12A2.5 2.5 0 0 1 11 2.5zm-8.5 4a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3zm11 5.5a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3z"/> </svg>
 
     useEffect(() => {
-        getData(`sessions/${id}`, setData, setError)
+        getData(`sessions/${id}`, setData, setError,
+            ['session_players', 'players', 'game', 'user', 'collaborators', 'session_categories'])
     }, [create, addPlayers, editDate, enterScores, deletePlayer, sessionShare])
 
     useEffect(() => {
@@ -43,25 +44,25 @@ export const Session = () => {
     }, [])
 
     const WIN_TYPE = {true: 'WON!', false: 'Not won'}
-    const styling = {gridTemplateColumns: `repeat(${data?.session?.session_players?.length + 1}, ${100/(data?.session?.session_players?.length + 1)}%)`}
+    const styling = {gridTemplateColumns: `repeat(${data?.session_players?.length + 1}, ${100/(data?.session_players?.length + 1)}%)`}
 
     const add_players = [...Array(numPlayers)].map((x, i) => (
         <div key={i}>
             <div>Player {i + 1}</div>
             <Form submitter={true} endpoint="session_players" item='session_player' updater={newData} setter={setData} setError={setError}>
                 <Input type="select_text" name="name" options={data?.players ? data.players : [{name: 'foo'}, {name: 'bar'}]}/>
-                <Input type="hidden" name="session_id" value={data?.session?.id} />
+                <Input type="hidden" name="session_id" value={data?.id} />
                 <Submit nobutton={true}>Save</Submit>
             </Form>
         </div>
     ))
 
-    const players = data?.session?.session_players?.map((player) => player)
+    const players = data?.session_players?.map((player) => player)
 
     const totals = (
         <div className="row" style={styling}>
             <div>TOTALS</div>
-            {data?.session?.session_players?.map((p) => (
+            {data?.session_players?.map((p) => (
                 <div key={p.id} >{p.session_scores?.map(s => s.amount).reduce((a, v) => a + v, 0)}</div>
             ))}
         </div>
@@ -70,7 +71,8 @@ export const Session = () => {
     const handleCalculate = async (e) => {
         setEnterScores(true)
         e?.preventDefault()
-        const response = await getData(`sessions/${data?.session?.id}/winner`, setData, setError)
+        const response = await getData(`sessions/${data?.id}/winner`, setData, setError,
+            ['session_players', 'players', 'game', 'user', 'collaborators', 'session_categories'])
         setEnterScores(false)
         alert(response.message)
     };
@@ -86,9 +88,9 @@ export const Session = () => {
         e.preventDefault()
         setDeletePlayer(true)
         window.confirm('Are you sure you want to delete this player')
-        await fetch(`api/session_players/${id}`, { method: 'delete'})
-        handleCalculate()
+        await fetch(`/api/session_players/${id}`, { method: 'delete'})
         setDeletePlayer(false)
+        handleCalculate()
     }
 
     if (!user) return <h1>No Content Here!</h1>
@@ -99,17 +101,17 @@ export const Session = () => {
         <div className="table">
             <div className="session-overview top-session">
                 <div className="game-name">
-                    <h2>{data?.session?.game?.name}</h2>
+                    <h2>{data?.game?.name}</h2>
                     <Button handler={deleteHandler} classes={`delete-button`}>Delete Session&nbsp;<div className="x"> X </div></Button>
                 </div>
-                <h3>Creator: {data?.session?.user.name}</h3>
+                <h3>Creator: {data?.user?.name}</h3>
                 <div className="shared-entry">
-                    <h3>Shared With: {data?.session?.collaborators?.map(c => c.name)}</h3>
+                    <h3>Shared With: {data?.collaborators?.map(c => c?.name)}</h3>
                     <Switcher setter={setSessionShare} data={sessionShare}>{share_img}</Switcher>
                 </div>
                 {sessionShare ? 
                 <div className="wide-form">
-                    <Form endpoint={`sessions/${data?.session?.id}/session_shares`} item='share' updater={newData} setter={setData} setToggle={setSessionShare} setError={setError}>
+                    <Form endpoint={`sessions/${data?.id}/session_shares`} item='share' updater={newData} setter={setData} setToggle={setSessionShare} setError={setError}>
                         <Input type="text" name="email" placeHolder='Email'/>
                         <Submit>Share</Submit>
                     </Form> 
@@ -117,17 +119,17 @@ export const Session = () => {
                 }
                 <div className="entry date-entry">
                     <h3>{editDate ?
-                        <Form endpoint="sessions" item='session' id={data?.session?.id} updater={updateData}
+                        <Form endpoint="sessions" item='session' id={data?.id} updater={updateData}
                             setter={setData} setToggle={setEditDate} setError={setError}>
-                            <Input type="date" name="date" value={data?.session?.date} />
+                            <Input type="date" name="date" value={data?.date} />
                             <Submit>Save Date</Submit>
                         </Form> :
-                        <>{data?.session?.date}</>
+                        <>{data?.date}</>
                     }
                     </h3>
-                    <Switcher setter={setEditDate} data={editDate}>{editDate ? 'Done Editing' : 'Change Date'}</Switcher>
+                    <Switcher setter={setEditDate} data={editDate}>{editDate ? '' : 'Change Date'}</Switcher>
                 </div>
-                <h3>Winner: {data?.session?.victor || 'None Yet'}</h3>
+                <h3>Winner: {data?.victor || 'None Yet'}</h3>
             </div>
 
             <div className="session-data">
@@ -136,7 +138,7 @@ export const Session = () => {
                     <h3>Players</h3>
                     {players?.map((p) => (
                         <div key={p.id} style={{display: 'flex', width: '100%', alignItems: 'center'}}>
-                            {p.name}&nbsp;
+                            {p?.name}&nbsp;
                             <Button handler={(e) => playerDelete(e, p.id)} classes={`delete-button`}><div className="x"> X </div></Button>
                         </div>
                         )

--- a/app/javascript/components/__tests__/ScoresTable.test.js
+++ b/app/javascript/components/__tests__/ScoresTable.test.js
@@ -8,26 +8,24 @@ import userEvent from '@testing-library/user-event'
 const user = userEvent.setup()
 
 const data = {
-    session: {
-        session_categories: [
-            {   id: 1, 
-                name: 'Cat A',
-                point_based: true,
-                session_scores: [
-                    { id: 11, amount: 11, win: false},
-                    { id: 12, amount: 12, win: false},
-                ]
-            },
-            {   id: 2, 
-                name: 'Cat B',
-                point_based: false,
-                session_scores: [
-                    { id: 13, amount: 13, win: false},
-                    { id: 14, amount: 14, win: true},
-                ]
-            },
-        ]
-    }
+    session_categories: [
+        {   id: 1, 
+            name: 'Cat A',
+            point_based: true,
+            session_scores: [
+                { id: 11, amount: 11, win: false},
+                { id: 12, amount: 12, win: false},
+            ]
+        },
+        {   id: 2, 
+            name: 'Cat B',
+            point_based: false,
+            session_scores: [
+                { id: 13, amount: 13, win: false},
+                { id: 14, amount: 14, win: true},
+            ]
+        },
+    ]
 }
 
 const styling = null

--- a/app/javascript/components/__tests__/Session.test.js
+++ b/app/javascript/components/__tests__/Session.test.js
@@ -44,13 +44,10 @@ describe('Session component works correctly',() => {
     });
 
     test('You can change the date', async () => {
-        render(<Session/>)
+        render(<Session />)
         expect(screen.queryByText('Save Date')).toBe(null)
         await user.click(screen.getByText('Change Date'))
         expect(screen.getByText('Save Date')).toBeDefined()
-        await user.click(screen.getByText('Save Date'))
-        await user.click(screen.getByText('Done Editing'))
-        expect(screen.queryByText('Save Date')).toBe(null)
     });
 
     test('You can share a session', async () => {

--- a/app/javascript/components/helpers/api_helpers.js
+++ b/app/javascript/components/helpers/api_helpers.js
@@ -16,7 +16,8 @@ const putPostData = async (endpoint, type, info) => {
 }
 
 const getHelper = async (endpoint, include) => {
-    const included_associations = include ? `?include=${include.join(',')}` : ''
+    const param_mark = endpoint.match(/\?/) ? '&' : '?'
+    const included_associations = include ? `${param_mark}include=${include.join(',')}` : ''
     const response=await fetch(`/api/${endpoint}${included_associations}`)
     if (response.status > 400){
         throw new Error(`${response.status}: ${response.statusText}`)

--- a/app/javascript/components/helpers/api_helpers.js
+++ b/app/javascript/components/helpers/api_helpers.js
@@ -15,17 +15,18 @@ const putPostData = async (endpoint, type, info) => {
     }) 
 }
 
-const getHelper = async (endpoint) => {
-    const response=await fetch(`/api/${endpoint}`)
+const getHelper = async (endpoint, include) => {
+    const included_associations = include ? `?include=${include.join(',')}` : ''
+    const response=await fetch(`/api/${endpoint}${included_associations}`)
     if (response.status > 400){
         throw new Error(`${response.status}: ${response.statusText}`)
     }
     return response
 }
 
-export const getData= async (endpoint, setter, setError)=>{
+export const getData= async (endpoint, setter, setError, include=null)=>{
     try {
-        const response=await getHelper(endpoint)
+        const response=await getHelper(endpoint, include)
         const data=await response.json()
         await setter(data)
         return data

--- a/app/javascript/components/helpers/useSetUser.js
+++ b/app/javascript/components/helpers/useSetUser.js
@@ -8,7 +8,7 @@ export const useSetUser = (toggle = null) => {
     const [error, setError] = useState(null)
 
     useEffect(() => {
-        getData('user', setUser, setError)
+        getData('user', setUser, setError, ['sessions', 'shared_sessions'])
     }, [loading, error, toggle])
 
     return {loading: loading, setLoading: setLoading, user: user, setUser: setUser, error: error, setError: setError }

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -21,17 +21,6 @@ class Game < ApplicationRecord
 		.order('sessions_count DESC, games.created_at')
 		.limit(5)
 	}
-
-	def game_relationships
-		self.to_json(:include => 
-		[ :categories, 
-			{:sessions => {only: [:id, :date, :victor, :user_id],
-				:include => [
-					{ :session_shares => {only: [:collaborator_id]} }
-				]} 
-			}]
-		)
-	end
 	
 	def results
 		self&.sessions

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -33,18 +33,6 @@ class Session < ApplicationRecord
 		result.length == 1 ? "#{first_player} wins this round of #{self.game.name}!" : "Tied between: #{result.map{|p| category_winner ? p.first : p.name}.join(", ")}"
 	end
 
-	def session_relationships
-
-		self.to_json(:include => 
-			[:game, :user, :collaborators, 
-				{:session_players => {:include => [:session_scores]}}, 
-				{:session_categories => {:include => [:session_scores]}},
-				{:session_scores => {:include => [:session_player, :session_category]}}
-			]
-		)
-
-	end
-
 	private
 
 	def create_categories

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -1,48 +1,60 @@
 class Session < ApplicationRecord
-    belongs_to :game
-    belongs_to :user
-    has_many :session_categories,  -> { order(id: :asc) }, dependent: :destroy
-    has_many :session_players,  -> { order(id: :asc) }, dependent: :destroy
-    has_many :session_scores, -> { order(id: :asc)}, dependent: :destroy
-    has_many :session_shares, foreign_key: 'shared_session_id'
-    has_many :collaborators, :through => :session_shares
+	belongs_to :game
+	belongs_to :user
+	has_many :session_categories,  -> { order(id: :asc) }, dependent: :destroy
+	has_many :session_players,  -> { order(id: :asc) }, dependent: :destroy
+	has_many :session_scores, -> { order(id: :asc)}, dependent: :destroy
+	has_many :session_shares, foreign_key: 'shared_session_id'
+	has_many :collaborators, :through => :session_shares
 
-    accepts_nested_attributes_for :session_players, :session_scores
+	accepts_nested_attributes_for :session_players, :session_scores
 
-    after_create :create_categories
+	after_create :create_categories
 
-    def share(email)
-        u = User.where("LOWER(email) = ?", email.downcase).first
-        if u
-            self.session_shares.create!(collaborator_id: u.id)
-            send_shared_email(u)
-            return "Share with #{email} successful!"
-        else
-            raise StandardError, "No user with email #{email} found"
-        end
-    end
+	def share(email)
+		u = User.where("LOWER(email) = ?", email.downcase).first
+		if u
+				self.session_shares.create!(collaborator_id: u.id)
+				send_shared_email(u)
+				return "Share with #{email} successful!"
+		else
+				raise StandardError, "No user with email #{email} found"
+		end
+	end
 
-    def winner
-        category_winners = self.session_players.map{|p| [p.name, p.winning_categories.size]}.select{|e| !e.last.zero?}
-        max = category_winners&.max_by{|c| c&.last}&.last || self.session_players.map(&:total_score).max
-        result = category_winners.map(&:last).sum > 0 ? 
-            category_winners.select{|c| c.last == max} : self.session_players.select {|p| p.total_score == max}
-        category_winner = !category_winners.map(&:last).sum.zero? ? true : false
-        first_player = category_winner ? result&.first&.first : result&.first&.name
-        result.length == 1 ? self.update(victor: first_player) : self.update(victor: 'Tied')
-        result.length == 1 ? "#{first_player} wins this round of #{self.game.name}!" : "Tied between: #{result.map{|p| category_winner ? p.first : p.name}.join(", ")}"
-    end
+	def winner
+		category_winners = self.session_players.map{|p| [p.name, p.winning_categories.size]}.select{|e| !e.last.zero?}
+		max = category_winners&.max_by{|c| c&.last}&.last || self.session_players.map(&:total_score).max
+		result = category_winners.map(&:last).sum > 0 ? 
+				category_winners.select{|c| c.last == max} : self.session_players.select {|p| p.total_score == max}
+		category_winner = !category_winners.map(&:last).sum.zero? ? true : false
+		first_player = category_winner ? result&.first&.first : result&.first&.name
+		result.length == 1 ? self.update(victor: first_player) : self.update(victor: 'Tied')
+		result.length == 1 ? "#{first_player} wins this round of #{self.game.name}!" : "Tied between: #{result.map{|p| category_winner ? p.first : p.name}.join(", ")}"
+	end
 
-    private
+	def session_relationships
 
-    def send_shared_email(u)
-       SessionMailer.with(user: u, date: self.date.strftime("%m/%d/%Y") , game: self.game.name, sharer: self.user.name, id: self.id)
-            .shared_email
-            .deliver_later
-    end
+		self.to_json(:include => 
+			[:game, :user, :collaborators, 
+				{:session_players => {:include => [:session_scores]}}, 
+				{:session_categories => {:include => [:session_scores]}},
+				{:session_scores => {:include => [:session_player, :session_category]}}
+			]
+		)
 
-    def create_categories
-        self.game.categories.each{|c| self.session_categories.create(name: c.name, point_based: c.point_based, win: c.win)}
-    end
+	end
+
+	private
+
+	def create_categories
+ 		self.game.categories.each{|c| self.session_categories.create(name: c.name, point_based: c.point_based, win: c.win)}
+	end
+
+	def send_shared_email(u)
+		SessionMailer.with(user: u, date: self.date.strftime("%m/%d/%Y") , game: self.game.name, sharer: self.user.name, id: self.id)
+				.shared_email
+				.deliver_later
+	end
 
 end


### PR DESCRIPTION
(rebased this branch to most recent state of main, so I'm re-creating the PR)

### Controllers

- created build_include methods for each controller
- added include param logic for each controller to account for that param in calls to the API

### Components

- added include params to any calls to the API endpoints
- edited shared methods to take in an "includes" array to work that into the fetch call

### Other
- Fixed indentation in app/models/session.rb, so that's 46 lines without any actual code changes!